### PR TITLE
feat: add filter to control enqueing of baguettebox assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here are the features of baguetteBox.js:
 
 Don't forget to select Link to → Media File for all of your Galleries & Images to work properly.
 
-**Notice**: At the moment, just Blocks inside a post are supported. Not Blocks in a Widget. You can make it work but have to enqueue the necessary style & script yourself. See *FAQ* --> *How to enqueue the necessary script & style for blocks outside of posts?*
+**Notice**: At the moment, just Blocks inside a post are supported. Not Blocks in a Widget. You can make it work but have to enqueue the necessary style & script yourself. See *FAQ* --> *How to enqueue the necessary assets (script & style) for blocks outside of posts or for block types that are not supported by default?*
 
 ## Installation
 
@@ -69,30 +69,45 @@ Set *Media File* to *None* or remove the Link.
 Since WordPress 5.6 you can now set the default behavior for *Link to*. Go to `yourblog.com/wp-admin/options.php` and search for `image_default_link_type`. Set the value to `file` and hit save. This will apply to all new Image & Gallery Blocks.
 
 Or you can add the follow snipped (WordPress 5.7+ / PHP 7.4+) to your functions.php:
-
-`add_filter('option_image_default_link_type', fn () => 'file');`
+```
+add_filter( 'option_image_default_link_type', fn () => 'file' );
+```
 
 ### How can I add my own Block? / Can I change the CSS selector?
 
 You can change the CSS selector to a gallery (or galleries) containing `<a>` tags used by [baguetteBox.js](https://github.com/feimosi/baguetteBox.js#api) with the `baguettebox_selector` filter:
-
-`apply_filter( 'baguettebox_selector', function($selector) { return $selector . ',.my-gallery'; } )`
-
+```
+add_filter( 'baguettebox_selector', function( $selector ) { return $selector . ',.my-gallery'; } )
+```
 You can override the full selector by just returing your selector e.g. to show all images in your post in one lightbox (not per Gallery/Image Block):
+```
+add_filter( 'baguettebox_selector', function() { return '.entry-content'; } )
+```
 
-`apply_filter( 'baguettebox_selector', function() { return '.entry-content'; } )`
+### How to enqueue the necessary assets (script & style) for blocks outside of posts or for block types that are not supported by default?
 
-### How to enqueue the necessary script & style for blocks outside of posts?
+If you use a Gallery or Image Block outside a post e.g. inside a Widget and want to apply the Lightbox, you need to ensure that the required baguettebox assets (script & style) are queued using the baguettebox_enqueue_assets filter.
 
-If you use a Gallery or Image Block outside a post e.g. inside a Widget and want to apply the Lightbox, you have to make sure to enqueue the necessary script & style.
-
-If the Widget is on every page or the majority of sites, you can just enqueue the script `baguettebox` & style `baguettebox-css` everywhere. Just add the following action to your `functions.php`:
-
-`add_action( 'wp_enqueue_scripts', function () { wp_enqueue_script( 'baguettebox' ); wp_enqueue_style( 'baguettebox-css' ); } );`
-
-If your Widget is just at the front page, you can add a check for `is_front_page()`:
-
-`add_action( 'wp_enqueue_scripts', function () { if ( is_front_page() ) { wp_enqueue_script( 'baguettebox' ); wp_enqueue_style( 'baguettebox-css' ); } } );`
+If the Widget is on every page or the majority of pages, you can just enqueue the baguettebox assets everywhere. Just add the following snippet to `functions.php`:
+```
+add_filter( 'baguettebox_enqueue_assets', '__return_true' );
+```
+If your Widget is just at the front page, use `is_front_page()`:
+```
+add_filter( 'baguettebox_enqueue_assets', function( $enqueue_assets ) { return is_front_page(); } );
+```
+If you want to use the Gallery & Image Block Lightbox plugin with a block type that is not supported by default, you can make use of the `has_block()` function. For instance, in the case of the Kadence Blocks Advanced Gallery, use:
+```
+add_filter( 'baguettebox_enqueue_assets', function ( $enqueue_assets ) {
+	return $enqueue_assets || has_block( 'kadence/advancedgallery' );
+} );
+```
+Of course, in the previous example you also have to add the appropriate baguettebox selector, i.e.
+```
+add_filter( 'baguettebox_selector', function( $selector ) {
+	return $selector . ',.wp-block-kadence-advancedgallery';
+} );
+```
 
 ## Screenshots
 
@@ -102,6 +117,10 @@ If your Widget is just at the front page, you can add a check for `is_front_page
 If you would like to have this as a default behaviour, go to `yourblog.com/wp-admin/options.php` and search for `image_default_link_type`. Set the value to `file` and hit save. This will apply to all new Image & Gallery Blocks.
 
 ## Changelog
+
+### 1.10.2
+
+- Add filter baguettebox_enqueue_assets to control enqueing of baguettebox assets.
 
 ### 1.10.1
 

--- a/gallery-block-lightbox.php
+++ b/gallery-block-lightbox.php
@@ -5,7 +5,7 @@
  * Description:  Adds a Lightbox to the Block Editor (Gutenberg) Gallery & Image Block.
  * Author:       Johannes Kinast <johannes@travel-dealz.de>
  * Author URI:   https://go-around.de
- * Version:     1.10.1
+ * Version:     1.10.2
  */
 namespace Gallery_Block_Lightbox;
 
@@ -14,21 +14,21 @@ function register_assets() {
 	wp_register_script( 'baguettebox', plugin_dir_url( __FILE__ ) . 'dist/baguetteBox.min.js', [], '1.11.1', true );
 
 	/**
-     * Filters the CSS selector of baguetteBox.js
-     *
-     * @since 1.10.0
-     *
-     * @param string  $value  The CSS selector to a gallery (or galleries) containing a tags
-     */
-	$baguettebox_selector = apply_filters('baguettebox_selector', '.wp-block-gallery,:not(.wp-block-gallery)>.wp-block-image,.wp-block-media-text__media,.gallery,.wp-block-coblocks-gallery-masonry,.wp-block-coblocks-gallery-stacked,.wp-block-coblocks-gallery-collage,.wp-block-coblocks-gallery-offset,.wp-block-coblocks-gallery-stacked' );
+	 * Filters the CSS selector of baguetteBox.js
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param string  $value  The CSS selector to a gallery (or galleries) containing a tags
+	 */
+	$baguettebox_selector = apply_filters( 'baguettebox_selector', '.wp-block-gallery,:not(.wp-block-gallery)>.wp-block-image,.wp-block-media-text__media,.gallery,.wp-block-coblocks-gallery-masonry,.wp-block-coblocks-gallery-stacked,.wp-block-coblocks-gallery-collage,.wp-block-coblocks-gallery-offset,.wp-block-coblocks-gallery-stacked' );
 
 	/**
-     * Filters the image files filter of baguetteBox.js
-     *
-     * @since 1.10.0
-     *
-     * @param string  $value  The RegExp Pattern to match image files. Applied to the a.href attribute
-     */
+	 * Filters the image files filter of baguetteBox.js
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param string  $value  The RegExp Pattern to match image files. Applied to the a.href attribute
+	 */
 	$baguettebox_filter = apply_filters( 'baguettebox_filter',  '/.+\.(gif|jpe?g|png|webp|svg|avif|heif|heic|tif?f|)($|\?)/i' );
 
 	wp_add_inline_script( 'baguettebox', 'window.addEventListener("load", function() {baguetteBox.run("' . $baguettebox_selector . '",{captions:function(t){var e=t.parentElement.classList.contains("wp-block-image")||t.parentElement.classList.contains("wp-block-media-text__media")?t.parentElement.querySelector("figcaption"):t.parentElement.parentElement.querySelector("figcaption,dd");return!!e&&e.innerHTML},filter:' . $baguettebox_filter . '});});' );
@@ -37,7 +37,27 @@ function register_assets() {
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_assets' );
 
 function enqueue_assets() {
-	if ( has_block( 'core/gallery' ) || has_block( 'core/image' ) || has_block( 'core/media-text' ) || get_post_gallery() || has_block('coblocks/gallery-masonry') || has_block('coblocks/gallery-stacked') || has_block('coblocks/gallery-collage') || has_block('coblocks/gallery-offset') || has_block('coblocks/gallery-stacked') ) {
+
+	/**
+	 * Filters whether baguettebox assets have to be enqueued.
+	 *
+	 * @since 1.10.2
+	 *
+	 * @param bool  $value  Whether baguettebox assets have to be enqueued.
+	 */
+	$baguettebox_enqueue_assets = apply_filters( 'baguettebox_enqueue_assets',
+		has_block( 'core/gallery' ) ||
+		has_block( 'core/image' ) ||
+		has_block( 'core/media-text' ) ||
+		get_post_gallery() ||
+		has_block( 'coblocks/gallery-masonry' ) ||
+		has_block( 'coblocks/gallery-stacked' ) ||
+		has_block( 'coblocks/gallery-collage' ) ||
+		has_block( 'coblocks/gallery-offset' ) ||
+		has_block( 'coblocks/gallery-stacked' )
+	);
+
+	if ( $baguettebox_enqueue_assets ) {
 		wp_enqueue_script( 'baguettebox' );
 		wp_enqueue_style( 'baguettebox-css' );
 	}


### PR DESCRIPTION
I would like to suggest filtering the condition whether to enqueue the baguettebox assets, too. Suppose a user wants to use a Kadence Blocks Advanced Gallery with the Gallery & Image Block Lightbox plugin. Then he can simply add the baguettebox selector `.wp-block-kadence-advancedgallery`, but he has to workaround the enqueuing of the baguettebox assets for the block `kadence/advancedgallery`. Filtering the condition by a baguettebox_enqueue_assets filter would make life easier.