### PR TITLE
Add filter to allow BaguetteBox animation to be set

### DIFF
--- a/gallery-block-lightbox.php
+++ b/gallery-block-lightbox.php
@@ -62,7 +62,6 @@ function register_assets() {
 	$baguettebox_options = "{captions:{$baguettebox_captions},filter:{$baguettebox_filter},ignoreClass:'{$baguettebox_ignoreclass}',animation:'{$baguettebox_animation}'}";
 
 	wp_add_inline_script( "baguettebox", "window.addEventListener('load', function() {baguetteBox.run('{$baguettebox_selector}',{$baguettebox_options});});" );
-
 }
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_assets' );
 

--- a/gallery-block-lightbox.php
+++ b/gallery-block-lightbox.php
@@ -49,8 +49,17 @@ function register_assets() {
 	 */
 	$baguettebox_captions = apply_filters( 'baguettebox_captions', 'function(t){var e=t.parentElement.classList.contains("wp-block-image")||t.parentElement.classList.contains("wp-block-media-text__media")?t.parentElement.querySelector("figcaption"):t.parentElement.parentElement.querySelector("figcaption,dd");return!!e&&e.innerHTML}' );
 
-	wp_add_inline_script( 'baguettebox', 'window.addEventListener("load", function() {baguetteBox.run("' . $baguettebox_selector . '",{captions:' . $baguettebox_captions . ',filter:' . $baguettebox_filter . ',ignoreClass:"' . $baguettebox_ignoreclass . '"});});' );
+	/**
+	 * Filters the animation attribute of baguetteBox.js
+	 *
+	 * @since 1.16
+	 *
+	 * @param string  $value  Use the given animation style on image transitions.
+	 * 'slideIn' | 'fadeIn' | 'false'
+	 */
+	$baguettebox_animation = apply_filters( 'baguettebox_animation', 'slideIn' );
 
+	wp_add_inline_script( 'baguettebox', 'window.addEventListener("load", function() {baguetteBox.run("' . $baguettebox_selector . '",{captions:' . $baguettebox_captions . ',filter:' . $baguettebox_filter . ',ignoreClass:"' . $baguettebox_ignoreclass . '",animation:"' . $baguettebox_animation . '"});});' );
 }
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_assets' );
 

--- a/gallery-block-lightbox.php
+++ b/gallery-block-lightbox.php
@@ -59,7 +59,10 @@ function register_assets() {
 	 */
 	$baguettebox_animation = apply_filters( 'baguettebox_animation', 'slideIn' );
 
-	wp_add_inline_script( 'baguettebox', 'window.addEventListener("load", function() {baguetteBox.run("' . $baguettebox_selector . '",{captions:' . $baguettebox_captions . ',filter:' . $baguettebox_filter . ',ignoreClass:"' . $baguettebox_ignoreclass . '",animation:"' . $baguettebox_animation . '"});});' );
+	$baguettebox_options = "{captions:{$baguettebox_captions},filter:{$baguettebox_filter},ignoreClass:'{$baguettebox_ignoreclass}',animation:'{$baguettebox_animation}'}";
+
+	wp_add_inline_script( "baguettebox", "window.addEventListener('load', function() {baguetteBox.run('{$baguettebox_selector}',{$baguettebox_options});});" );
+
 }
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_assets' );
 


### PR DESCRIPTION
This adds another filter along the lines of the existing ones to permit setting the BaguetteBox animation option.
The default in BaguetteBox is slideIn which some people find visually disturbing when large images move rapidly across the screen.

There's also a change to the way the variables are combined to create the inline script.
This is now done using PHP string interpolation to avoid breaking up the string.
Options are handled separately, again for clarity.