### PR TITLE
Draft: Feat: Add filter to customise all options for baguettebox

### DIFF
--- a/gallery-block-lightbox.php
+++ b/gallery-block-lightbox.php
@@ -9,6 +9,34 @@
  */
 namespace Gallery_Block_Lightbox;
 
+function is_js_function($value) {
+	return preg_match('/^function\s*\w*\s*\(/', $value);
+}
+
+function is_js_regex($value) {
+	return preg_match('/^\/.+\/([gimsuy]*)$/', $value);
+}
+
+function to_js_value($value){
+	if (is_string($value) && (is_js_function($value) || is_js_regex($value))) {
+		return $value;
+	}
+	return json_encode($value);
+}
+
+/**
+ * Build JavaScript object from PHP array
+ *
+ * This does not create a JSON object, because strings containing functions must be kept as JS functions.
+ * Therefore, `json_encode` can not be used directly.
+ */
+function php_array_to_js_object($array) {
+	$parts = array_map(function ($key, $value) {
+		return sprintf('%s: %s', $key, to_js_value($value));
+	}, array_keys($array), $array);
+	return '{' . implode(',', $parts) . '}';
+}
+
 function register_assets() {
 	wp_register_style( 'baguettebox-css', plugin_dir_url( __FILE__ ) . 'dist/baguetteBox.min.css', [], '1.12.0' );
 	wp_register_script( 'baguettebox', plugin_dir_url( __FILE__ ) . 'dist/baguetteBox.min.js', [], '1.12.0', true );
@@ -41,7 +69,7 @@ function register_assets() {
 	$baguettebox_ignoreclass = apply_filters( 'baguettebox_ignoreclass', 'no-lightbox' );
 
 	/**
-	 * Filters the captions  attribute of baguetteBox.js
+	 * Filters the captions attribute of baguetteBox.js
 	 *
 	 * @since 1.15
 	 *
@@ -59,9 +87,23 @@ function register_assets() {
 	 */
 	$baguettebox_animation = apply_filters( 'baguettebox_animation', 'slideIn' );
 
-	$baguettebox_options = "{captions:{$baguettebox_captions},filter:{$baguettebox_filter},ignoreClass:'{$baguettebox_ignoreclass}',animation:'{$baguettebox_animation}'}";
+	/**
+	 * Filters the options for baguetteBox.js
+     * For available options see https://github.com/feimosi/baguetteBox.js/?tab=readme-ov-file#customization
+     *
+     * @since 1.17
+     *
+     * @param array $options The customization options for baguetteBox
+	 */
+	$baguettebox_options = apply_filters( 'baguettebox_options', [
+		'captions' => $baguettebox_captions,
+		'filter' => $baguettebox_filter,
+		'ignoreClass' => $baguettebox_ignoreclass,
+		'animation' => $baguettebox_animation,
+	] );
+	$baguettebox_options_js = php_array_to_js_object($baguettebox_options);
 
-	wp_add_inline_script( "baguettebox", "window.addEventListener('load', function() {baguetteBox.run('{$baguettebox_selector}',{$baguettebox_options});});" );
+	wp_add_inline_script( "baguettebox", "window.addEventListener('load', function() {baguetteBox.run('{$baguettebox_selector}',{$baguettebox_options_js});});" );
 }
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_assets' );
 


### PR DESCRIPTION
First of all: Thank you for this awesome and simple plugin! It is exactly what I was looking for.

I tried to customise the appearance of the buttons in the frontend. I found the perfect configuration options in the [documentation of baguetteBox.js](https://github.com/feimosi/baguetteBox.js/?tab=readme-ov-file#customization), unfortunately they are currently not supported by this plugin. So I thought It would be great, to be able to customise all options, including future ones.

This PR adds the filter `baguettebox_options`. The value passed to the filter is an associative PHP array of the baguettebox options. The filtered result are parsed to a JS object (not JSON) before it is passed to the JS.

This allows customisation of all options without explicitly adding a filter for each one. Overall this provides flexibility and handle future extensions gracefully, while keeping backwards compatibility to the existing filters.

Sample usage:
```php
add_filter('baguettebox_options', function ($options) {
    $options['titleTag'] = false;
    $options['leftArrow'] = '<svg width="44" height="60"><polyline points="30 10 10 30 30 50" stroke="rgba(255,255,255,0.95)" stroke-width="4" stroke-linecap="butt" fill="none" stroke-linejoin="round"/></svg>';
    $options['afterShow'] = 'function () { console.log("baguettebox opened") }';
    $options['overlayBackgroundColor'] = 'rgba(255,0,0,0.8)';
    return $options;
});
```

This produces the following JS (line breaks and comment added for better readability, not existing on real page):
```js
window.addEventListener('load', function () {
    baguetteBox.run('.wp-block-gallery,:not(.wp-block-gallery)>.wp-block-image,.wp-block-media-text__media,.gallery,.wp-block-coblocks-gallery-masonry,.wp-block-coblocks-gallery-stacked,.wp-block-coblocks-gallery-collage,.wp-block-coblocks-gallery-offset,.wp-block-coblocks-gallery-stacked,.mgl-gallery,.gb-block-image', {
        captions: function (t) {
            var e = t.parentElement.classList.contains("wp-block-image") || t.parentElement.classList.contains("wp-block-media-text__media") ? t.parentElement.querySelector("figcaption") : t.parentElement.parentElement.querySelector("figcaption,dd");
            return !!e && e.innerHTML
        },
        filter: /.+\.(gif|jpe?g|png|webp|svg|avif|heif|heic|tif?f|)($|\?)/i,
        ignoreClass: "no-lightbox",
        animation: "slideIn",
        // customisations
        titleTag: false,
        leftArrow: "<svg width=\"44\" height=\"60\"><polyline points=\"30 10 10 30 30 50\" stroke=\"rgba(255,255,255,0.95)\" stroke-width=\"4\" stroke-linecap=\"butt\" fill=\"none\" stroke-linejoin=\"round\"\/><\/svg>",
        afterShow: function () {
            console.log("baguettebox opened")
        },
        overlayBackgroundColor: "rgba(255,0,0,0.8)"
    });
});
```

---

If you like the idea, I’d be happy to add some documentation to the readme before merging the PR.

I appreciate your feedback on this. 